### PR TITLE
make path is not to absolute

### DIFF
--- a/src/main/java/de/tomalbrc/danse/Danse.java
+++ b/src/main/java/de/tomalbrc/danse/Danse.java
@@ -104,7 +104,7 @@ public class Danse implements ModInitializer {
         try {
             for (Path path : loadFiles("danse", ".ajblueprint")) {
                 Danse.LOGGER.info("Loading player gesture model: {}", path.getFileName());
-                PlayerModelRegistry.addFrom(PlayerModelLoader.load(path.toAbsolutePath().toString()));
+                PlayerModelRegistry.addFrom(PlayerModelLoader.load(path.toString()));
             }
 
             var added = false;


### PR DESCRIPTION
in window system, absolute path is `DISK_ID://path/path/foo.ajblueprint`. 
the problem is `ResourceLocation` is not allow `:`. this cause exception when bli tries to load / register ajblueprint file.

i changed not to use absolute path. i tested in Windows 11/MacOS env, it works without any bugs.

