### PR TITLE
Fixes to optimize skin loading, implemented proper use of cache for skins

### DIFF
--- a/src/main/java/de/tomalbrc/danse/GestureController.java
+++ b/src/main/java/de/tomalbrc/danse/GestureController.java
@@ -5,8 +5,8 @@ import de.tomalbrc.danse.entity.GesturePlayerModelEntity;
 import de.tomalbrc.danse.poly.GestureCameraHolder;
 import de.tomalbrc.danse.registry.EntityRegistry;
 import de.tomalbrc.danse.registry.PlayerModelRegistry;
+import de.tomalbrc.danse.util.MinecraftSkinFetcher;
 import de.tomalbrc.danse.util.MinecraftSkinParser;
-import de.tomalbrc.danse.util.TextureCache;
 import de.tomalbrc.danse.util.Util;
 import eu.pb4.polymer.core.api.utils.PolymerUtils;
 import eu.pb4.polymer.virtualentity.api.VirtualEntityUtils;
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -32,9 +33,8 @@ public class GestureController {
 
     public static void onConnect(ServerPlayer serverPlayer) {
         // to have a cached model/texture of players
-        TextureCache.fetch(serverPlayer.getGameProfile(), image -> {
-            MinecraftSkinParser.calculate(serverPlayer.getUUID(), image, x -> {});
-        });
+        MinecraftSkinFetcher.fetchSkinFromProfile(serverPlayer.getGameProfile(), skin ->
+                MinecraftSkinParser.calculateAndCache(serverPlayer.getUUID(), skin));
     }
 
     public static void onDisconnect(ServerPlayer serverPlayer) {
@@ -42,7 +42,7 @@ public class GestureController {
         if (cam != null) {
             onStop(cam);
         }
-        MinecraftSkinParser.remove(serverPlayer.getUUID());
+        MinecraftSkinParser.removeCachedData(serverPlayer.getUUID());
     }
 
     public static void onStop(ServerPlayer player) {
@@ -83,29 +83,37 @@ public class GestureController {
     }
 
     public static void onStart(ServerPlayer player, String animationName) {
-        TextureCache.fetch(player.getGameProfile(), image -> {
-            MinecraftSkinParser.calculate(player.getUUID(), image, dataMap -> {
-                // destroy any previous gestures
-                GestureCameraHolder camera = GestureController.GESTURE_CAMS.get(player.getUUID());
-                if (camera != null) {
-                    camera.destroy();
-                }
+        var cachedSkin = MinecraftSkinParser.getCachedData(player.getUUID());
 
-                GesturePlayerModelEntity playerModel = EntityRegistry.GESTURE_PLAYER_MODEL.create(player.level(), EntitySpawnReason.EVENT);
-                assert playerModel != null;
-                playerModel.setup(player, PlayerModelRegistry.getModel(animationName), dataMap);
-                playerModel.shouldCheckDistance(false);
-
-                GestureCameraHolder gestureCameraHolder = new GestureCameraHolder(player, playerModel);
-                GestureController.GESTURE_CAMS.put(player.getUUID(), gestureCameraHolder);
-
-                ChunkAttachment.ofTicking(gestureCameraHolder, player.level(), player.position());
-
-                // removes model etc when animation finishes
-                playerModel.playAnimation(animationName, (unused) -> GestureController.onStop(gestureCameraHolder));
-
-                player.level().addFreshEntity(playerModel);
+        if (cachedSkin != null) {
+            startGesture(player, animationName, cachedSkin);
+        } else {
+            MinecraftSkinFetcher.fetchSkinFromProfile(player.getGameProfile(), image -> {
+                startGesture(player, animationName, MinecraftSkinParser.calculateAndCache(player.getUUID(), image));
             });
-        });
+        }
+    }
+
+    private static void startGesture(ServerPlayer player, String animationName, Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> skinData) {
+        // destroy any previous gestures
+        GestureCameraHolder camera = GestureController.GESTURE_CAMS.get(player.getUUID());
+        if (camera != null) {
+            camera.destroy();
+        }
+
+        GesturePlayerModelEntity playerModel = EntityRegistry.GESTURE_PLAYER_MODEL.create(player.level(), EntitySpawnReason.EVENT);
+        assert playerModel != null;
+        playerModel.setup(player, PlayerModelRegistry.getModel(animationName), skinData);
+        playerModel.shouldCheckDistance(false);
+
+        GestureCameraHolder gestureCameraHolder = new GestureCameraHolder(player, playerModel);
+        GestureController.GESTURE_CAMS.put(player.getUUID(), gestureCameraHolder);
+
+        ChunkAttachment.ofTicking(gestureCameraHolder, player.level(), player.position());
+
+        // removes model etc when animation finishes
+        playerModel.playAnimation(animationName, x -> GestureController.onStop(gestureCameraHolder));
+
+        player.level().addFreshEntity(playerModel);
     }
 }

--- a/src/main/java/de/tomalbrc/danse/entity/StatuePlayerModelEntity.java
+++ b/src/main/java/de/tomalbrc/danse/entity/StatuePlayerModelEntity.java
@@ -3,14 +3,13 @@ package de.tomalbrc.danse.entity;
 import com.mojang.authlib.GameProfile;
 import de.tomalbrc.bil.api.AnimatedEntity;
 import de.tomalbrc.bil.core.model.Model;
-import de.tomalbrc.danse.Danse;
 import de.tomalbrc.danse.mixin.ArmorStandInvoker;
 import de.tomalbrc.danse.poly.PlayerPartHolder;
 import de.tomalbrc.danse.poly.StatuePlayerPartHolder;
 import de.tomalbrc.danse.registry.ItemRegistry;
 import de.tomalbrc.danse.registry.PlayerModelRegistry;
+import de.tomalbrc.danse.util.MinecraftSkinFetcher;
 import de.tomalbrc.danse.util.MinecraftSkinParser;
-import de.tomalbrc.danse.util.TextureCache;
 import de.tomalbrc.danse.util.Util;
 import de.tomalbrc.dialogutils.DialogUtils;
 import eu.pb4.polymer.virtualentity.api.attachment.EntityAttachment;
@@ -32,7 +31,7 @@ import net.minecraft.world.level.storage.ValueOutput;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.image.BufferedImage;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -97,11 +96,12 @@ public class StatuePlayerModelEntity extends ArmorStand implements AnimatedEntit
         this.url = valueInput.getStringOr(URL, null);
 
         if (this.url != null && !this.url.isBlank()) {
-            TextureCache.fetch(this.url, this::setTexture);
+            MinecraftSkinFetcher.fetchSkinFromUrl(this.url, image ->
+                    this.setTexture(MinecraftSkinParser.calculate(image)));
         } else if (this.playerName != null || this.playerUuid != null) {
             fetchGameProfile(this::setProfile);
         } else {
-            this.setTexture(Danse.STEVE_TEXTURE);
+            this.setTexture(MinecraftSkinParser.STEVE_SKIN);
         }
         this.holder.setEquipment(this.equipment);
     }
@@ -134,11 +134,18 @@ public class StatuePlayerModelEntity extends ArmorStand implements AnimatedEntit
         this.playerName = profile.name();
         this.playerUuid = profile.id();
 
-        TextureCache.fetch(profile, this::setTexture);
+        var cachedSkin = MinecraftSkinParser.getCachedData(profile.id());
+        if (cachedSkin != null) {
+            setTexture(cachedSkin);
+        } else {
+            MinecraftSkinFetcher.fetchSkinFromProfile(profile, image -> {
+                setTexture(MinecraftSkinParser.calculateAndCache(profile.id(), image));
+            });
+        }
     }
 
-    public void setTexture(BufferedImage image) {
-        MinecraftSkinParser.calculate(playerUuid, image, data -> this.holder.setSkinData(data));
+    public void setTexture(Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> data) {
+        this.holder.setSkinData(data);
     }
 
     public void fetchGameProfile(Consumer<GameProfile> cb) {

--- a/src/main/java/de/tomalbrc/danse/item/StatuePlayerModelItem.java
+++ b/src/main/java/de/tomalbrc/danse/item/StatuePlayerModelItem.java
@@ -1,8 +1,8 @@
 package de.tomalbrc.danse.item;
 
-import de.tomalbrc.danse.Danse;
 import de.tomalbrc.danse.entity.StatuePlayerModelEntity;
 import de.tomalbrc.danse.registry.EntityRegistry;
+import de.tomalbrc.danse.util.MinecraftSkinParser;
 import de.tomalbrc.danse.util.Util;
 import de.tomalbrc.dialogutils.DialogUtils;
 import eu.pb4.polymer.core.api.item.PolymerItem;
@@ -70,7 +70,7 @@ public class StatuePlayerModelItem extends ArmorStandItem implements PolymerItem
                         profile.resolveProfile(DialogUtils.SERVER.services().profileResolver()).thenAccept(statue::setProfile);
                     }
                     else {
-                        statue.setTexture(Danse.STEVE_TEXTURE);
+                        statue.setTexture(MinecraftSkinParser.STEVE_SKIN);
                     }
 
                     float yRot = (float) Mth.floor((Mth.wrapDegrees(useOnContext.getRotation() - 180.0F) + 22.5F) / 45.0F) * 45.0F;

--- a/src/main/java/de/tomalbrc/danse/util/MinecraftSkinFetcher.java
+++ b/src/main/java/de/tomalbrc/danse/util/MinecraftSkinFetcher.java
@@ -2,82 +2,86 @@ package de.tomalbrc.danse.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.mojang.authlib.GameProfile;
+import de.tomalbrc.danse.Danse;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 public class MinecraftSkinFetcher {
-    public static final Gson gson = new Gson();
+    private static final Gson gson = new Gson();
     private static final Map<String, CompletableFuture<BufferedImage>> FUTURE_CACHE = new ConcurrentHashMap<>();
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
-    public static void fetchSkin(String base64val, Consumer<BufferedImage> callback) {
+    public static void fetchSkinFromEncodedProfile(String base64val, Consumer<BufferedImage> callback) {
         String decodedJson = new String(Base64.getDecoder().decode(base64val));
         JsonObject textureData = gson.fromJson(decodedJson, JsonObject.class);
         var url = textureData.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
-        fetchSkinFromURL(url, callback);
+        fetchSkinFromUrl(url, callback);
     }
 
-    public static void fetchSkinFromURL(String url, Consumer<BufferedImage> callback) {
-
-        var future = FUTURE_CACHE.computeIfAbsent(url, key -> CompletableFuture.supplyAsync(() -> {
-            if (url != null) {
-                try {
-                    return downloadSkin(url);
-                } catch (IOException | InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            return null;
-        }).thenApply(skinData -> {
-            if (skinData != null) {
-                try {
-                    var img = ImageIO.read(new ByteArrayInputStream(skinData));
-                    FUTURE_CACHE.remove(url);
-                    return img;
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            return null;
-        }).exceptionally(throwable -> {
-            throwable.printStackTrace();
-            return null;
-        }));
-
-        if (future.isDone()) {
-            try {
-                callback.accept(future.get());
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            future.thenAccept(callback);
+    public static void fetchSkinFromProfile(GameProfile profile, Consumer<BufferedImage> onFinish) {
+        if (!profile.properties().containsKey("textures")) {
+            onFinish.accept(Danse.STEVE_TEXTURE);
+            return;
         }
+
+        var skin = Danse.SERVER.services().sessionService().getTextures(profile).skin();
+        if (skin == null) {
+            onFinish.accept(Danse.STEVE_TEXTURE);
+            return;
+        }
+
+        fetchSkinFromUrl(skin.getUrl(), onFinish);
+    }
+
+    public static void fetchSkinFromUrl(String url, Consumer<BufferedImage> onFinish) {
+        FUTURE_CACHE.computeIfAbsent(url, x -> CompletableFuture
+                .supplyAsync(() -> {
+                    try {
+                        byte[] skinImageBytes = downloadSkin(url);
+                        return ImageIO.read(new ByteArrayInputStream(skinImageBytes));
+                    } catch (IOException | InterruptedException e) {
+                        throw new CompletionException(e);
+                    }
+                })
+                .whenComplete((result, error) -> {
+                    FUTURE_CACHE.remove(url);
+                    if (error != null) {
+                        Danse.LOGGER.error("Error fetching skin from URL: {}",
+                                url, error.getCause() != null ? error.getCause() : error);
+                        Danse.SERVER.execute(() -> onFinish.accept(Danse.STEVE_TEXTURE));
+                    } else {
+                        Danse.SERVER.execute(() -> onFinish.accept(result));
+                    }
+                })
+        );
     }
 
     public static byte[] downloadSkin(String skinUrl) throws IOException, InterruptedException {
-        try (InputStream in = HttpClient.newHttpClient()
-                .send(HttpRequest.newBuilder().uri(URI.create(skinUrl)).GET().build(),
-                        HttpResponse.BodyHandlers.ofInputStream()).body();
-             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[1024];
-            int r;
-            while ((r = in.read(buffer)) > 0) out.write(buffer, 0, r);
-            return out.toByteArray();
+        try (InputStream in = HTTP_CLIENT
+                .send(HttpRequest.newBuilder()
+                                .uri(URI.create(skinUrl))
+                                .timeout(Duration.ofSeconds(10))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofInputStream())
+                .body()) {
+            return in.readAllBytes();
         }
     }
 }

--- a/src/main/java/de/tomalbrc/danse/util/MinecraftSkinParser.java
+++ b/src/main/java/de/tomalbrc/danse/util/MinecraftSkinParser.java
@@ -1,6 +1,7 @@
 package de.tomalbrc.danse.util;
 
 import com.google.common.collect.ImmutableList;
+import de.tomalbrc.danse.Danse;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.Identifier;
@@ -22,12 +23,14 @@ public class MinecraftSkinParser {
     public static final Map<BodyPart, Map<Layer, Map<Direction, int[]>>> SLIM_TEXTURE_MAP = new EnumMap<>(BodyPart.class);
 
     private static final Map<UUID, Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData>> PARSED_CACHE = new ConcurrentHashMap<>();
+    public static final Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> STEVE_SKIN;
     public static final ImmutableList<Direction> DIRECTIONS = ImmutableList.of(Direction.SOUTH, Direction.NORTH, Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN);
 
     static {
         defineSteveTextures(CLASSIC_TEXTURE_MAP);
         defineNotchTextures(CLASSIC_TEXTURE_MAP, NOTCH_TEXTURE_MAP);
         defineAlexTextures(CLASSIC_TEXTURE_MAP, SLIM_TEXTURE_MAP);
+        STEVE_SKIN = calculateAndCache(new UUID(0, 0), Danse.STEVE_TEXTURE);
     }
 
     private static void defineNotchTextures(Map<BodyPart, Map<Layer, Map<Direction, int[]>>> classic, Map<BodyPart, Map<Layer, Map<Direction, int[]>>> notch) {
@@ -337,13 +340,7 @@ public class MinecraftSkinParser {
         return new ColorData(rgb);
     }
 
-    public static void calculate(UUID id, BufferedImage image, Consumer<Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData>> onFinish) {
-        var cached = PARSED_CACHE.get(id);
-        if (cached != null) {
-            onFinish.accept(cached);
-            return;
-        }
-
+    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculate(BufferedImage image) {
         Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> data = new Object2ObjectArrayMap<>();
         for (MinecraftSkinParser.BodyPart part : MinecraftSkinParser.BodyPart.values()) {
             List<Integer> colors = new ArrayList<>();
@@ -372,11 +369,20 @@ public class MinecraftSkinParser {
             data.put(part, new MinecraftSkinParser.PartData(innerCmd, outerCmd, MinecraftSkinParser.isSlimSkin(image)));
         }
 
-        if (image != null && id != null) PARSED_CACHE.put(id, data);
-        onFinish.accept(data);
+        return data;
     }
 
-    public static void remove(UUID i) {
+    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculateAndCache(UUID id, BufferedImage image) {
+        var data = calculate(image);
+        if (image != null && id != null) PARSED_CACHE.put(id, data);
+        return data;
+    }
+
+    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> getCachedData(UUID id) {
+        return PARSED_CACHE.get(id);
+    }
+
+    public static void removeCachedData(UUID i) {
         PARSED_CACHE.remove(i);
     }
 

--- a/src/main/java/de/tomalbrc/danse/util/TextureCache.java
+++ b/src/main/java/de/tomalbrc/danse/util/TextureCache.java
@@ -2,7 +2,6 @@ package de.tomalbrc.danse.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
-import com.mojang.authlib.GameProfile;
 import de.tomalbrc.danse.Danse;
 import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -19,44 +18,16 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.awt.image.Raster;
 import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
 public class TextureCache {
     private static final Map<CacheKey, CustomModelData> ARMOR_CACHE = new ConcurrentHashMap<>();
     private static final Map<CacheKey, CustomModelData> TRIM_CACHE = new ConcurrentHashMap<>();
     private static List<Integer> PALETTE_KEY;
-
-    public static void fetch(GameProfile profile, Consumer<BufferedImage> onFinish) {
-        if (profile.properties().containsKey("textures")) {
-            var skin = Danse.SERVER.services().sessionService().getTextures(profile).skin();
-            if (skin == null) {
-                onFinish.accept(Danse.STEVE_TEXTURE);
-                return;
-            }
-
-            var url = skin.getUrl();
-            try {
-                var img = ImageIO.read(new URI(url).toURL());
-                Danse.SERVER.execute(()-> onFinish.accept(img));
-            } catch (IOException | URISyntaxException e) {
-                throw new RuntimeException(e);
-            }
-
-        } else {
-            onFinish.accept(Danse.STEVE_TEXTURE);
-        }
-    }
-
-    public static void fetch(String url, Consumer<BufferedImage> onFinish) {
-        MinecraftSkinFetcher.fetchSkinFromURL(url, onFinish);
-    }
 
     public static CustomModelData armorCustomModelData(MinecraftSkinParser.BodyPart part, ItemStack itemStack, boolean inner) {
         if (!itemStack.has(DataComponents.EQUIPPABLE))


### PR DESCRIPTION
My server froze a few times because of the on connect event handler which fetches the skin of the connecting player on the main thread. I took a look into the code and made a few changes to improve things and implemented some caching. Now all skin fetching code is async and the mod will check the parsed skin cache when possible instead of making a request every time.

- Skin fetching on player connect wasn't async, so it could freeze the main thread. All skin fetching no longer runs on the main thread.
- Skin fetching method moved from TextureCache to MinecraftSkinFetcher.
- Clean up skin fetching code in MinecraftSkinFetcher
- Make MinecraftSkinParser actually use its PARSED_CACHE. Now every time a player executes a gesture, the mod will use the cached data instead of making a request for the player's skin
- Change code relying on MinecraftSkinParser or MinecraftSkinFetcher to check the cache first and use that data before fetching the skin from the server, parsing, then caching
- Change code relying on BufferedImage to use the cached output of MinecraftSkinParser instead