### PR TITLE
Fix not correctly displaying slim models in some cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,18 @@ loom {
     accessWidenerPath = file("src/main/resources/danse.accesswidener")
 }
 
+configurations {
+    shade
+    implementation.extendsFrom(shade)
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
     maven { url "https://maven.tomalbrc.de" }
     maven { url 'https://maven.nucleoid.xyz' }
     maven { url 'https://maven.blamejared.com' }
+    maven { url "https://cursemaven.com" }
 }
 
 dependencies {
@@ -33,8 +39,8 @@ dependencies {
     implementation include("eu.pb4:placeholder-api:${project.papi_version}")
     implementation include("eu.pb4:sgui:${project.sgui_version}")
 
-    implementation include("de.tomalbrc:blockbench-import-library:${project.bil_version}")
-    implementation include("de.tomalbrc:DialogUtils:${project.dialogutils_version}")
+    // "de.tomalbrc:blockbench-import-library:2.0.6+26.2; no longer available in tom's maven"
+    implementation include("curse.maven:blockbench-import-library-1118767:8267864")
     implementation include("de.tomalbrc:DialogUtils:${project.dialogutils_version}")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,6 @@ loom {
     accessWidenerPath = file("src/main/resources/danse.accesswidener")
 }
 
-configurations {
-    shade
-    implementation.extendsFrom(shade)
-}
-
 repositories {
     mavenLocal()
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ fabric_version=0.152.1+26.2
 polymer_version=0.17.0+26.2-rc-2
 # https://github.com/Patbox/map-canvas-api/releases
 mapcanvas_version=0.9.0+26.2
-bil_version=2.0.6+26.2
 dialogutils_version=1.8.4+26.1
 papi_version=3.1.0-beta.1+26.2
 sgui_version=2.1.0+26.2

--- a/src/main/java/de/tomalbrc/danse/Danse.java
+++ b/src/main/java/de/tomalbrc/danse/Danse.java
@@ -11,6 +11,7 @@ import de.tomalbrc.danse.registry.EntityRegistry;
 import de.tomalbrc.danse.registry.ItemRegistry;
 import de.tomalbrc.danse.registry.PlayerModelRegistry;
 import de.tomalbrc.danse.util.GestureDialog;
+import de.tomalbrc.danse.util.MinecraftSkinData;
 import de.tomalbrc.dialogutils.util.FontUtil;
 import eu.pb4.polymer.autohost.impl.AutoHostConfig;
 import eu.pb4.polymer.common.impl.CommonImpl;
@@ -48,6 +49,7 @@ public class Danse implements ModInitializer {
     public static ResourcePackBuilder RESOURCEPACK_BUILDER;
     public static Logger LOGGER = LogUtils.getLogger();
     public static BufferedImage STEVE_TEXTURE;
+    public static MinecraftSkinData STEVE_SKIN;
 
     public static Int2IntArrayMap VIRTUAL_ENTITY_PICK_MAP = new Int2IntArrayMap();
 
@@ -91,6 +93,8 @@ public class Danse implements ModInitializer {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        STEVE_SKIN = new MinecraftSkinData(STEVE_TEXTURE, MinecraftSkinData.Model.WIDE);
 
         ServerPlayConnectionEvents.JOIN.register((serverGamePacketListener, packetSender, minecraftServer) -> GestureController.onConnect(serverGamePacketListener.player));
         ServerPlayConnectionEvents.DISCONNECT.register((serverGamePacketListener, minecraftServer) -> GestureController.onDisconnect(serverGamePacketListener.player));

--- a/src/main/java/de/tomalbrc/danse/util/MinecraftSkinData.java
+++ b/src/main/java/de/tomalbrc/danse/util/MinecraftSkinData.java
@@ -1,0 +1,29 @@
+package de.tomalbrc.danse.util;
+
+import java.awt.image.BufferedImage;
+
+public record MinecraftSkinData(BufferedImage image, Model model) {
+    private static final int TEXTURE_WIDTH = 64;
+    private static final int TEXTURE_HEIGHT = 64;
+
+    public enum Model {
+        WIDE, SLIM;
+
+        public static Model from(String str) {
+            if ("slim".equalsIgnoreCase(str)) return SLIM;
+            return WIDE;
+        }
+    }
+
+    public static Model guessSkinModel(BufferedImage image) {
+        boolean isSlim = image.getWidth() == TEXTURE_WIDTH &&
+                image.getHeight() == TEXTURE_HEIGHT &&
+                image.getRGB(50, 16) == 0;
+
+        return isSlim ? Model.SLIM : Model.WIDE;
+    }
+
+    public static MinecraftSkinData from(BufferedImage image) {
+        return new MinecraftSkinData(image, guessSkinModel(image));
+    }
+}

--- a/src/main/java/de/tomalbrc/danse/util/MinecraftSkinFetcher.java
+++ b/src/main/java/de/tomalbrc/danse/util/MinecraftSkinFetcher.java
@@ -27,29 +27,50 @@ public class MinecraftSkinFetcher {
     private static final Map<String, CompletableFuture<BufferedImage>> FUTURE_CACHE = new ConcurrentHashMap<>();
     private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
-    public static void fetchSkinFromEncodedProfile(String base64val, Consumer<BufferedImage> callback) {
+    public static void fetchSkinFromEncodedProfile(String base64val, Consumer<MinecraftSkinData> callback) {
         String decodedJson = new String(Base64.getDecoder().decode(base64val));
         JsonObject textureData = gson.fromJson(decodedJson, JsonObject.class);
-        var url = textureData.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
-        fetchSkinFromUrl(url, callback);
+
+        JsonObject skin = textureData
+                .getAsJsonObject("textures")
+                .getAsJsonObject("SKIN");
+
+        String url = skin.get("url").getAsString();
+
+        JsonObject metadata = skin.getAsJsonObject("metadata");
+
+        String modelStr = (metadata != null && metadata.has("model"))
+                ? metadata.get("model").getAsString()
+                : null;
+
+        MinecraftSkinData.Model model =
+                MinecraftSkinData.Model.from(modelStr);
+
+        fetchSkinImageFromUrl(url,
+                image -> callback.accept(new MinecraftSkinData(image, model)));
     }
 
-    public static void fetchSkinFromProfile(GameProfile profile, Consumer<BufferedImage> onFinish) {
+    public static void fetchSkinFromProfile(GameProfile profile, Consumer<MinecraftSkinData> onFinish) {
         if (!profile.properties().containsKey("textures")) {
-            onFinish.accept(Danse.STEVE_TEXTURE);
+            onFinish.accept(Danse.STEVE_SKIN);
             return;
         }
 
         var skin = Danse.SERVER.services().sessionService().getTextures(profile).skin();
         if (skin == null) {
-            onFinish.accept(Danse.STEVE_TEXTURE);
+            onFinish.accept(Danse.STEVE_SKIN);
             return;
         }
 
-        fetchSkinFromUrl(skin.getUrl(), onFinish);
+        var model = MinecraftSkinData.Model.from(skin.getMetadata("model"));
+        fetchSkinImageFromUrl(skin.getUrl(), image -> onFinish.accept(new MinecraftSkinData(image, model)));
     }
 
-    public static void fetchSkinFromUrl(String url, Consumer<BufferedImage> onFinish) {
+    public static void fetchSkinFromUrl(String url, Consumer<MinecraftSkinData> onFinish) {
+        fetchSkinImageFromUrl(url, image -> onFinish.accept(MinecraftSkinData.from(image)));
+    }
+
+    public static void fetchSkinImageFromUrl(String url, Consumer<BufferedImage> onFinish) {
         FUTURE_CACHE.computeIfAbsent(url, x -> CompletableFuture
                 .supplyAsync(() -> {
                     try {

--- a/src/main/java/de/tomalbrc/danse/util/MinecraftSkinParser.java
+++ b/src/main/java/de/tomalbrc/danse/util/MinecraftSkinParser.java
@@ -16,8 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 public class MinecraftSkinParser {
-    private static final int TEXTURE_WIDTH = 64;
-    private static final int TEXTURE_HEIGHT = 64;
+
     public static final Map<BodyPart, Map<Layer, Map<Direction, int[]>>> NOTCH_TEXTURE_MAP = new EnumMap<>(BodyPart.class);
     public static final Map<BodyPart, Map<Layer, Map<Direction, int[]>>> CLASSIC_TEXTURE_MAP = new EnumMap<>(BodyPart.class);
     public static final Map<BodyPart, Map<Layer, Map<Direction, int[]>>> SLIM_TEXTURE_MAP = new EnumMap<>(BodyPart.class);
@@ -30,7 +29,7 @@ public class MinecraftSkinParser {
         defineSteveTextures(CLASSIC_TEXTURE_MAP);
         defineNotchTextures(CLASSIC_TEXTURE_MAP, NOTCH_TEXTURE_MAP);
         defineAlexTextures(CLASSIC_TEXTURE_MAP, SLIM_TEXTURE_MAP);
-        STEVE_SKIN = calculateAndCache(new UUID(0, 0), Danse.STEVE_TEXTURE);
+        STEVE_SKIN = calculateAndCache(new UUID(0, 0), Danse.STEVE_SKIN);
     }
 
     private static void defineNotchTextures(Map<BodyPart, Map<Layer, Map<Direction, int[]>>> classic, Map<BodyPart, Map<Layer, Map<Direction, int[]>>> notch) {
@@ -252,12 +251,6 @@ public class MinecraftSkinParser {
         map.put(BodyPart.LEFT_LEG, leftLegMap);
     }
 
-    public static boolean isSlimSkin(BufferedImage image) {
-        return image.getWidth() == TEXTURE_WIDTH &&
-                image.getHeight() == TEXTURE_HEIGHT &&
-                image.getRGB(50, 16) == 0;
-    }
-
     public static void extractTextureRGB(BufferedImage image, Map<BodyPart, Map<Layer, Map<Direction, int[]>>> textureMap, BodyPart part, Layer layer, Direction direction, Consumer<ColorData> consumer) {
         Map<Layer, Map<Direction, int[]>> partMap = textureMap.get(part);
         if (partMap == null) return;
@@ -285,10 +278,19 @@ public class MinecraftSkinParser {
         }
     }
 
-    public static void extractTextureRGB(BufferedImage image, BodyPart part, Layer layer, Direction direction, Consumer<ColorData> consumer) {
-        boolean isSlim = isSlimSkin(image);
-        Map<BodyPart, Map<Layer, Map<Direction, int[]>>> textureMap = isSlim ? SLIM_TEXTURE_MAP : image.getHeight() > 32 ? CLASSIC_TEXTURE_MAP : NOTCH_TEXTURE_MAP;
-        extractTextureRGB(image, textureMap, part, layer, direction, consumer);
+    public static void extractTextureRGB(MinecraftSkinData skin, BodyPart part, Layer layer, Direction direction, Consumer<ColorData> consumer
+    ) {
+        Map<BodyPart, Map<Layer, Map<Direction, int[]>>> textureMap;
+
+        if (skin.model() == MinecraftSkinData.Model.SLIM) {
+            textureMap = SLIM_TEXTURE_MAP;
+        } else if (skin.image().getHeight() > 32) {
+            textureMap = CLASSIC_TEXTURE_MAP;
+        } else {
+            textureMap = NOTCH_TEXTURE_MAP;
+        }
+
+        extractTextureRGB(skin.image(), textureMap, part, layer, direction, consumer);
     }
 
     private static void eastTex(BufferedImage image, Consumer<ColorData> consumer, int width, int height, int startX, int startY) {
@@ -340,14 +342,14 @@ public class MinecraftSkinParser {
         return new ColorData(rgb);
     }
 
-    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculate(BufferedImage image) {
+    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculate(MinecraftSkinData skin) {
         Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> data = new Object2ObjectArrayMap<>();
         for (MinecraftSkinParser.BodyPart part : MinecraftSkinParser.BodyPart.values()) {
             List<Integer> colors = new ArrayList<>();
             List<Boolean> alphas = new ArrayList<>();
 
             for (Direction direction : DIRECTIONS) {
-                MinecraftSkinParser.extractTextureRGB(image, part, MinecraftSkinParser.Layer.INNER, direction, colorData -> {
+                MinecraftSkinParser.extractTextureRGB(skin, part, MinecraftSkinParser.Layer.INNER, direction, colorData -> {
                     colors.add(colorData.color());
                     alphas.add(colorData.alpha());
                 });
@@ -355,9 +357,9 @@ public class MinecraftSkinParser {
 
             List<Integer> colorsOuter = new ArrayList<>();
             List<Boolean> alphasOuter = new ArrayList<>();
-            if (image.getHeight() > 32) {
+            if (skin.image().getHeight() > 32) {
                 for (final Direction direction : DIRECTIONS) {
-                    MinecraftSkinParser.extractTextureRGB(image, part, MinecraftSkinParser.Layer.OUTER, direction, colorData -> {
+                    MinecraftSkinParser.extractTextureRGB(skin, part, MinecraftSkinParser.Layer.OUTER, direction, colorData -> {
                         colorsOuter.add(colorData.color());
                         alphasOuter.add(colorData.alpha());
                     });
@@ -366,15 +368,15 @@ public class MinecraftSkinParser {
 
             CustomModelData innerCmd = new CustomModelData(ImmutableList.of(), alphas, ImmutableList.of(), colors);
             CustomModelData outerCmd = new CustomModelData(ImmutableList.of(), alphasOuter, ImmutableList.of(), colorsOuter);
-            data.put(part, new MinecraftSkinParser.PartData(innerCmd, outerCmd, MinecraftSkinParser.isSlimSkin(image)));
+            data.put(part, new MinecraftSkinParser.PartData(innerCmd, outerCmd, skin.model() == MinecraftSkinData.Model.SLIM));
         }
 
         return data;
     }
 
-    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculateAndCache(UUID id, BufferedImage image) {
-        var data = calculate(image);
-        if (image != null && id != null) PARSED_CACHE.put(id, data);
+    public static Map<MinecraftSkinParser.BodyPart, MinecraftSkinParser.PartData> calculateAndCache(UUID id, MinecraftSkinData skin) {
+        var data = calculate(skin);
+        if (skin != null && id != null) PARSED_CACHE.put(id, data);
         return data;
     }
 


### PR DESCRIPTION
In some cases, the player's skin can be using the slim model but still have non-transparent pixels in the line of pixels removed from the arm in the slim model. Some players on my server and even myself have had the regular, wide model be displayed when gesturing despite using slim player skins. 

This fix checks the player's profile for the model type and passes it down to SkinParser so that it can use the correct texture map even if the texture doesn't have transparent pixels in the arm area. URLs do not have this information available, so the mod will fall back to using the "arm has transparent pixels" check for slim models if only the URL and no metadata is available.